### PR TITLE
Add collection shortcodes

### DIFF
--- a/booqable.php
+++ b/booqable.php
@@ -233,6 +233,12 @@ function booqable_categories_bb($params) {
   return '<div class="booqable-categories" ' . shortcode_options_to_data($options) . '></div>';
 }
 
+// BBcode for embedding a collection list
+// [booqable_collection]
+function booqable_collections_bb($params) {
+  return '<div class="booqable-collections"></div>';
+}
+
 
 function initialize() {
   add_action('admin_menu', 'booqable_admin_actions');
@@ -259,6 +265,7 @@ function initialize() {
   add_shortcode('booqable_sort', 'booqable_sort_bb');
   add_shortcode('booqable_bar', 'booqable_bar_bb');
   add_shortcode('booqable_categories', 'booqable_categories_bb');
+  add_shortcode('booqable_collections', 'booqable_collections_bb');
 }
 initialize();
 

--- a/booqable.php
+++ b/booqable.php
@@ -123,11 +123,12 @@ function booqable_detail_bb($params) {
 // BBcode for embedding a product list
 // [booqable_list]
 // [booqable_list tags="tablets"]
-// [booqable_list categories="apple"]
+// [booqable_list collections="apple"]
 function booqable_list_bb($params) {
   $options = shortcode_atts(array(
     'tags'        => NULL,
     'categories'  => NULL,
+    'collections' => NULL,
     'per'         => NULL,
     'limit'       => NULL,
     'show-search' => NULL,
@@ -194,7 +195,7 @@ function booqable_embeddable_cart_sidebar_bb($params) {
   return '<div class="booqable-embeddable-cart-sidebar" ' . shortcode_options_to_data($options) . '></div>';
 }
 
-// BBcode for embedding a sidebar with datepicker and categories
+// BBcode for embedding a sidebar with datepicker and collections
 // [booqable_sidebar]
 function booqable_sidebar_bb($params) {
   return '<div class="booqable-sidebar"></div>';
@@ -222,9 +223,9 @@ function booqable_bar_bb($params) {
   return '<div class="booqable-bar" ' . shortcode_options_to_data($options) . '></div>';
 }
 
+// DEPRECATED: Please use [booqable_collection] instead
 // BBcode for embedding a category list
 // [booqable_categories]
-// [booqable_categories search-key="only-tablets"]
 function booqable_categories_bb($params) {
   $options = shortcode_atts(array(
     'search-key'  => NULL

--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ This plugin seamlessly connects your WordPress website to your Booqable account,
 ## Key Features:
 
 ### Effortless Product Integration:
-Utilize customizable shortcodes to showcase your rental products across your WordPress pages. Enjoy full support for categories, variations, bundles, multiple images, and flexible pricing settings.
+Utilize customizable shortcodes to showcase your rental products across your WordPress pages. Enjoy full support for collections, variations, bundles, multiple images, and flexible pricing settings.
 
 ### Real-Time Availability:
 Stay ahead with a comprehensive booking calendar featuring real-time inventory availability updates. Whether you're receiving orders online or in person, Booqable ensures your inventory remains synchronized, preventing any risk of overbooking.


### PR DESCRIPTION
This PR adds shortcodes that uses collections. The category based shortcodes have been left for backwards compatibility.

These are now possible, and should be used:
`[booqable_collection]`
`[booqable_list collections="apple"]`